### PR TITLE
fix: Fallback to unnamed id field for schema

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -57,7 +57,7 @@ export async function buildSchema(dbPath: string): Promise<SchemaDatabase | unde
     results.forEach(raw => {
         let r = raw["_"];
         let doc: SchemaDocument = {
-            id: raw["id"],
+            id: raw["id"] ?? raw["$1"],
             keys: [],
             parent: schema
         };


### PR DESCRIPTION
In some DB versions (pre-3.0?) `meta().id` does not resolve to a named column, but rather `$1`. This allows the plugin to fallback to that column if `id` isn't present.